### PR TITLE
chore/db: add test table migration

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -4,3 +4,11 @@
 - Para crear una migración: `npx supabase migration new <cambio>` y commitearla.
 - Para probar local (opcional): `supabase start`, `supabase db reset`.
 - Para regenerar tipos manualmente: `pnpm run db:types` (o `npm run db:types`).
+
+## test
+Tabla temporal para validar el pipeline de migraciones.
+- id (uuid, pk)
+- label (text, 1–120 chars)
+- meta (jsonb, default {})
+- created_at (timestamptz, default now)
+RLS: desactivado (solo para smoke test). Borrar esta tabla cuando no se use.

--- a/supabase/migrations/20250908220732_create_test_table.sql
+++ b/supabase/migrations/20250908220732_create_test_table.sql
@@ -1,0 +1,14 @@
+-- smoke test migration: creates a minimal table to verify CI -> Supabase -> Vercel
+
+create table if not exists public.test (
+  id uuid primary key default gen_random_uuid(),
+  label text not null check (char_length(label) between 1 and 120),
+  meta jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+comment on table public.test is 'Temporary smoke-test table for CI/CD of DB';
+comment on column public.test.label is 'Short name for smoke test';
+
+-- RLS intentionally left DISABLED for this throwaway table to avoid client errors during the smoke test.
+-- Cleanup (manual): drop table if exists public.test;


### PR DESCRIPTION
## Summary
- add idempotent migration to create public.test table for smoke testing
- document temporary test table in schema docs

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bf539349b0832b81c6b7d41e5edcb2