### PR TITLE
ci: add pnpm lockfile workflows

### DIFF
--- a/.github/workflows/fix-lockfile.yml
+++ b/.github/workflows/fix-lockfile.yml
@@ -1,0 +1,50 @@
+name: Fix pnpm lockfile
+
+on:
+  # lo disparo manualmente desde la UI de Actions
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch a actualizar (ej: nombre de la rama del PR)
+        required: true
+        default: ${{ github.ref_name }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: PNPM version
+        run: pnpm -v
+
+      # Si usás paquetes privados, descomenta y agrega NPM_TOKEN en Secrets
+      # - name: Auth npm (privado)
+      #   run: npm config set //registry.npmjs.org/:_authToken "${{ secrets.NPM_TOKEN }}"
+
+      - name: Regenerar lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Commit si cambió el lockfile
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore(ci): sync pnpm-lock.yaml'
+          file_pattern: pnpm-lock.yaml
+          branch: ${{ github.event.inputs.ref }}

--- a/.github/workflows/pnpm-verify.yml
+++ b/.github/workflows/pnpm-verify.yml
@@ -1,0 +1,17 @@
+name: Verify pnpm lockfile
+
+on:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack enable
+      - run: pnpm --version
+      - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- add workflow to verify pnpm lockfile on pull requests
- add workflow to regenerate and commit pnpm-lock.yaml from CI

## Testing
- `pnpm --version`
- `pnpm install --frozen-lockfile` *(fails: ERR_PNPM_OUTDATED_LOCKFILE)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cb889928832b800d3890d4b49216