### PR TITLE
ci: pipelines Prod y Stage (migraciones + deploy) con --db-url explícito

### DIFF
--- a/.github/workflows/pipeline-prod.yml
+++ b/.github/workflows/pipeline-prod.yml
@@ -3,18 +3,21 @@ name: Production pipeline (Supabase migrate + Vercel deploy)
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'src/lib/database.types.ts'
   workflow_dispatch:
 
 concurrency:
   group: prod-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   migrate-and-deploy-prod:
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,19 +32,29 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           set -e
+          if [ -z "$SUPABASE_DB_URL" ]; then
+            echo "::error::Falta el secret SUPABASE_DB_URL"; exit 1
+          fi
+          if echo "$SUPABASE_DB_URL" | grep -qi "pool"; then
+            echo "::warning::La URL parece de pooling; se recomienda non-pooling para migraciones."
+          fi
           if [ -d "supabase/migrations" ] && [ "$(ls -A supabase/migrations)" ]; then
             supabase migration up --db-url "$SUPABASE_DB_URL" --non-interactive
           else
             echo "No hay migraciones en supabase/migrations; se omite."
           fi
 
-      - name: (Opcional) Generar tipos TypeScript desde Supabase
-        if: ${{ env.SUPABASE_PROJECT_REF != '' && env.SUPABASE_ACCESS_TOKEN != '' }}
+      - name: (Opcional) Generar types TS desde Supabase
+        env:
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          supabase gen types typescript \
-            --project-id "$SUPABASE_PROJECT_REF" \
-            --schema public > src/lib/database.types.ts || true
-          git status --porcelain | grep "database.types.ts" && echo "Tipos actualizados (no se commitea en CI)."
+          if [ -n "$SUPABASE_PROJECT_REF" ] && [ -n "$SUPABASE_ACCESS_TOKEN" ]; then
+            supabase gen types typescript --project-id "$SUPABASE_PROJECT_REF" --schema public > src/lib/database.types.ts
+            echo "Types generados (no se commitean en CI)."
+          else
+            echo "Secrets para gen types no configurados; se omite."
+          fi
 
       - name: Trigger Vercel Deploy (Prod)
         env:

--- a/.github/workflows/pipeline-stage.yml
+++ b/.github/workflows/pipeline-stage.yml
@@ -3,18 +3,21 @@ name: Stage pipeline (Supabase migrate + Vercel deploy)
 on:
   push:
     branches: [ stage ]
+    paths-ignore:
+      - 'src/lib/database.types.ts'
   workflow_dispatch:
 
 concurrency:
   group: stage-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   migrate-and-deploy-stage:
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROJECT_REF_STAGE: ${{ secrets.SUPABASE_PROJECT_REF_STAGE }}
-      SUPABASE_ACCESS_TOKEN_STAGE: ${{ secrets.SUPABASE_ACCESS_TOKEN_STAGE }}
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,19 +32,29 @@ jobs:
           SUPABASE_DB_URL_STAGE: ${{ secrets.SUPABASE_DB_URL_STAGE }}
         run: |
           set -e
+          if [ -z "$SUPABASE_DB_URL_STAGE" ]; then
+            echo "::error::Falta el secret SUPABASE_DB_URL_STAGE"; exit 1
+          fi
+          if echo "$SUPABASE_DB_URL_STAGE" | grep -qi "pool"; then
+            echo "::warning::La URL parece de pooling; se recomienda non-pooling para migraciones."
+          fi
           if [ -d "supabase/migrations" ] && [ "$(ls -A supabase/migrations)" ]; then
             supabase migration up --db-url "$SUPABASE_DB_URL_STAGE" --non-interactive
           else
             echo "No hay migraciones en supabase/migrations; se omite."
           fi
 
-      - name: (Opcional) Generar tipos TypeScript desde Supabase (Stage)
-        if: ${{ env.SUPABASE_PROJECT_REF_STAGE != '' && env.SUPABASE_ACCESS_TOKEN_STAGE != '' }}
+      - name: (Opcional) Generar types TS desde Supabase (Stage)
+        env:
+          SUPABASE_PROJECT_REF_STAGE: ${{ secrets.SUPABASE_PROJECT_REF_STAGE }}
+          SUPABASE_ACCESS_TOKEN_STAGE: ${{ secrets.SUPABASE_ACCESS_TOKEN_STAGE }}
         run: |
-          SUPABASE_PROJECT_REF="$SUPABASE_PROJECT_REF_STAGE" \
-          SUPABASE_ACCESS_TOKEN="$SUPABASE_ACCESS_TOKEN_STAGE" \
-          supabase gen types typescript --project-id "$SUPABASE_PROJECT_REF_STAGE" --schema public > /dev/null || true
-          echo "Tipos generados (no se commitea en CI)."
+          if [ -n "$SUPABASE_PROJECT_REF_STAGE" ] && [ -n "$SUPABASE_ACCESS_TOKEN_STAGE" ]; then
+            supabase gen types typescript --project-id "$SUPABASE_PROJECT_REF_STAGE" --schema public > /dev/null
+            echo "Types generados (no se commitean en CI)."
+          else
+            echo "Secrets para gen types (Stage) no configurados; se omite."
+          fi
 
       - name: Trigger Vercel Deploy (Stage)
         env:

--- a/README.md
+++ b/README.md
@@ -53,21 +53,12 @@ npm run dev:stage
 
 Recordatorio: no exponer `SUPABASE_SERVICE_ROLE_STAGE` ni `SUPABASE_DB_URL_STAGE` en el código cliente.
 
-## Pipelines
+## CI/CD
 
-Prod (main): corre `pipeline-prod.yml` → migraciones a `SUPABASE_DB_URL` → deploy vía `VERCEL_DEPLOY_HOOK_URL`.
+Prod (main): `pipeline-prod.yml` ⇒ migraciones con `--db-url` + deploy vía `VERCEL_DEPLOY_HOOK_URL`.
 
-Stage (stage): corre `pipeline-stage.yml` → migraciones a `SUPABASE_DB_URL_STAGE` → deploy vía `VERCEL_DEPLOY_HOOK_URL_STAGE`.
+Stage (stage): `pipeline-stage.yml` ⇒ migraciones con `--db-url` + deploy vía `VERCEL_DEPLOY_HOOK_URL_STAGE`.
 
-Se recomienda usar una URL de base de datos **non-pooling** para ejecutar migraciones.
+Recomendación: usar DB URL non-pooling para migraciones.
 
-### Secrets requeridos
-
-- `SUPABASE_DB_URL`
-- `VERCEL_DEPLOY_HOOK_URL`
-- `SUPABASE_PROJECT_REF` *(opcional)*
-- `SUPABASE_ACCESS_TOKEN` *(opcional)*
-- `SUPABASE_DB_URL_STAGE`
-- `VERCEL_DEPLOY_HOOK_URL_STAGE`
-- `SUPABASE_PROJECT_REF_STAGE` *(opcional)*
-- `SUPABASE_ACCESS_TOKEN_STAGE` *(opcional)*
+Recordatorio: los workflows deben existir en la rama destino; por eso los versionamos en main y luego creamos stage desde main.


### PR DESCRIPTION
## Cambios
- Se actualizan los workflows unificados `.github/workflows/pipeline-prod.yml` y `.github/workflows/pipeline-stage.yml` para aplicar migraciones con `--db-url` y disparar el deploy en Vercel.
- Se documenta el nuevo flujo en el README.

## Secrets
**Prod**
- `SUPABASE_DB_URL`
- `VERCEL_DEPLOY_HOOK_URL`
- `SUPABASE_PROJECT_REF` (opcional)
- `SUPABASE_ACCESS_TOKEN` (opcional)

**Stage**
- `SUPABASE_DB_URL_STAGE`
- `VERCEL_DEPLOY_HOOK_URL_STAGE`
- `SUPABASE_PROJECT_REF_STAGE` (opcional)
- `SUPABASE_ACCESS_TOKEN_STAGE` (opcional)

## Cómo probar
- Hacer push a `main` ejecuta `pipeline-prod.yml` (migraciones + deploy).
- Hacer push a `stage` ejecuta `pipeline-stage.yml` (migraciones + deploy).

## Notas
Tras mergear, se borrará y recreará la rama `stage` desde `main`.

------
https://chatgpt.com/codex/tasks/task_e_68c156657c0c832b9e0ce763e139b7c7